### PR TITLE
Gopher support

### DIFF
--- a/ttbp/core.py
+++ b/ttbp/core.py
@@ -73,6 +73,28 @@ def reload_ttbprc(ttbprc={}):
 
     SETTINGS = ttbprc
 
+
+def get_files():
+    """Returns a list of user's feels."""
+    files = []
+    for filename in os.listdir(config.USER_DATA):
+        if nopub(filename):
+            link = os.path.join(config.WWW,
+                                os.path.splitext(
+                                    os.path.basename(filename))[0]+".html")
+            if os.path.exists(link):
+                subprocess.call(["rm", link])
+            continue
+        filename = os.path.join(config.USER_DATA, filename)
+        if os.path.isfile(filename) and valid(filename):
+            files.append(filename)
+
+    files.sort()
+    files.reverse()
+
+    return files
+
+
 def load_files():
     '''
     file loader
@@ -83,20 +105,7 @@ def load_files():
 
     global FILES
 
-    FILES = []
-
-    for filename in os.listdir(config.USER_DATA):
-        if nopub(filename):
-            link = os.path.join(config.WWW, os.path.splitext(os.path.basename(filename))[0]+".html")
-            if os.path.exists(link):
-                subprocess.call(["rm", link])
-            continue
-        filename = os.path.join(config.USER_DATA, filename)
-        if os.path.isfile(filename) and valid(filename):
-            FILES.append(filename)
-
-    FILES.sort()
-    FILES.reverse()
+    FILES = get_files()
 
 
 ## html outputting

--- a/ttbp/gopher.py
+++ b/ttbp/gopher.py
@@ -17,17 +17,17 @@ If you don't know what it is or don't want it that is totally ok!
 You can always change this later.""".lstrip()
 
 GOPHERMAP_HEADER = """
-welcome to {user}'s feels on gopher.
+ welcome to {user}'s feels on gopher.
 
-    .::                     .::
-  .:                        .::
-.:.: .:   .::       .::     .:: .::::
-  .::   .:   .::  .:   .::  .::.::
-  .::  .::::: .::.::::: .:: .::  .:::
-  .::  .:        .:         .::    .::
-  .::    .::::     .::::   .:::.:: .::
+     .::                     .::
+   .:                        .::
+ .:.: .:   .::       .::     .:: .::::
+   .::   .:   .::  .:   .::  .::.::
+   .::  .::::: .::.::::: .:: .::  .:::
+   .::  .:        .:         .::    .::
+   .::    .::::     .::::   .:::.:: .::
 
-this file was created on their behalf by ttbp.
+ this file was created on their behalf by ttbp.
 
 """
 
@@ -53,12 +53,14 @@ def publish_gopher(gopher_path, entry_filenames):
         gophermap.write(GOPHERMAP_HEADER.format(
                         user=getpass.getuser()))
         for entry_filename in entry_filenames:
-            gophermap.write('0{file_label}\t{filename}'.format(
-                file_label=os.path.basename(entry_filename),
-                filename=entry_filename))
-            with open(os.path.join(ttbp_gopher, entry_filename), 'w') as gopher_entry:
+            filename = os.path.basename(entry_filename)
+
+            with open(os.path.join(ttbp_gopher, filename), 'w') as gopher_entry:
                 with open(entry_filename, 'r') as source_entry:
                     gopher_entry.write(source_entry.read())
+            gophermap.write('0{file_label}\t{filename}'.format(
+                file_label=os.path.basename(entry_filename),
+                filename=filename))
 
 
 def setup_gopher(gopher_path):
@@ -71,9 +73,13 @@ def setup_gopher(gopher_path):
     function.
     """
     public_gopher = os.path.expanduser('~/public_gopher')
-    if not os.path.is_dir(public_gopher):
+    if not os.path.isdir(public_gopher):
         print("\n\tERROR: you don't seem to have gopher set up (no public_gopher directory)")
         return
 
     ttbp_gopher = os.path.join(public_gopher, gopher_path)
-    os.mkdirs(ttbp_gopher)
+    if os.path.isdir(ttbp_gopher):
+        print("\n\tERROR: gopher path is already set up. quitting so we don't overwrite anything.")
+        return
+
+    os.makedirs(ttbp_gopher)

--- a/ttbp/gopher.py
+++ b/ttbp/gopher.py
@@ -1,0 +1,79 @@
+"""
+This module contains gopher-related stuff.
+"""
+import getpass
+import os
+
+from . import util
+
+GOPHER_PROMPT = """
+Would you like to publish your feels to gopher?
+
+gopher is a pre-web technology that is text-oriented and primarily used to
+share folders of your files with the world.
+
+If you don't know what it is or don't want it that is totally ok!
+
+You can always change this later.""".lstrip()
+
+GOPHERMAP_HEADER = """
+welcome to {user}'s feels on gopher.
+
+    .::                     .::
+  .:                        .::
+.:.: .:   .::       .::     .:: .::::
+  .::   .:   .::  .:   .::  .::.::
+  .::  .::::: .::.::::: .:: .::  .:::
+  .::  .:        .:         .::    .::
+  .::    .::::     .::::   .:::.:: .::
+
+this file was created on their behalf by ttbp.
+
+"""
+
+
+def select_gopher():
+    return util.input_yn(GOPHER_PROMPT)
+
+
+def publish_gopher(gopher_path, entry_filenames):
+    """This function (re)generates a user's list of feels posts in their gopher
+    directory and their gophermap."""
+    entry_filenames = entry_filenames[:]  # force a copy since this might be shared state in core.py
+    entry_filenames.reverse()
+    ttbp_gopher = os.path.join(
+        os.path.expanduser('~/public_gopher'),
+        gopher_path)
+
+    if not os.path.isdir(ttbp_gopher):
+        print('\n\tERROR: something is wrong. your gopher directory is missing. re-enable gopher publishing.')
+        return
+
+    with open(os.path.join(ttbp_gopher, 'gophermap'), 'w') as gophermap: 
+        gophermap.write(GOPHERMAP_HEADER.format(
+                        user=getpass.getuser()))
+        for entry_filename in entry_filenames:
+            gophermap.write('0{file_label}\t{filename}'.format(
+                file_label=os.path.basename(entry_filename),
+                filename=entry_filename))
+            with open(os.path.join(ttbp_gopher, entry_filename), 'w') as gopher_entry:
+                with open(entry_filename, 'r') as source_entry:
+                    gopher_entry.write(source_entry.read())
+
+
+def setup_gopher(gopher_path):
+    """Given a path relative to ~/public_gopher, this function:
+
+    - creates a directory under public_gopher
+    - creates a landing page
+
+    It doesn't create a gophermap as that is left to the publish_gopher
+    function.
+    """
+    public_gopher = os.path.expanduser('~/public_gopher')
+    if not os.path.is_dir(public_gopher):
+        print("\n\tERROR: you don't seem to have gopher set up (no public_gopher directory)")
+        return
+
+    ttbp_gopher = os.path.join(public_gopher, gopher_path)
+    os.mkdirs(ttbp_gopher)

--- a/ttbp/ttbp.py
+++ b/ttbp/ttbp.py
@@ -34,13 +34,11 @@ https://github.com/modgethanc/ttbp
 from __future__ import absolute_import
 
 import os
-import random
 import tempfile
 import subprocess
 import time
 import json
 from email.mime.text import MIMEText;
-import re
 import datetime
 
 import inflect

--- a/ttbp/ttbp.py
+++ b/ttbp/ttbp.py
@@ -393,7 +393,9 @@ def setup():
     print("\n\ttext editor:\t" +SETTINGS.get("editor"))
     if core.publishing():
         print("\tpublish dir:\t" +os.path.join(config.PUBLIC, str(SETTINGS.get("publish dir"))))
-    print("\tpubishing:\t"+str(SETTINGS.get("publishing"))+"\n")
+    print("\tpublishing:\t"+str(SETTINGS.get("publishing")))
+    print("\tgopher:\t"+str(SETTINGS.get('gopher')))
+    print("")
 
     # editor selection
     SETTINGS.update({"editor": select_editor()})
@@ -410,7 +412,7 @@ def setup():
 
     # gopher opt-in
     SETTINGS.update({'gopher': gopher.select_gopher()})
-    redraw('opting into gopher: ' + SETTINGS['gopher'])
+    redraw('opting into gopher: ' + str(SETTINGS['gopher']))
     # TODO for now i'm hardcoding where people's gopher stuff is generated. if
     # there is demand for this to be configurable we can expose that.
     gopher.setup_gopher('feels')

--- a/ttbp/ttbp.py
+++ b/ttbp/ttbp.py
@@ -30,6 +30,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 the complete codebase is available at:
 https://github.com/modgethanc/ttbp
+
+
+TODO ability to opt into gopher publishing
+TODO check for existing public_gopher / gophermap
+TODO write out files
 '''
 from __future__ import absolute_import
 
@@ -46,6 +51,7 @@ import inflect
 from . import config
 from . import core
 from . import chatter
+from . import gopher
 from . import util
 
 __version__ = "0.9.3"
@@ -56,7 +62,8 @@ p = inflect.engine()
 ## user globals
 SETTINGS = {
         "editor": "none",
-        "publish dir": False
+        "publish dir": False,
+        "gopher": False,
     }
 
 ## ui globals
@@ -401,6 +408,13 @@ def setup():
     if core.publishing():
         print("publish directory: ~"+config.USER+"/public_html/"+SETTINGS.get("publish dir"))
 
+    # gopher opt-in
+    SETTINGS.update({'gopher': gopher.select_gopher()})
+    redraw('opting into gopher: ' + SETTINGS['gopher'])
+    # TODO for now i'm hardcoding where people's gopher stuff is generated. if
+    # there is demand for this to be configurable we can expose that.
+    gopher.setup_gopher('feels')
+
     # save settings
     ttbprc = open(config.TTBPRC, "w")
     ttbprc.write(json.dumps(SETTINGS, sort_keys=True, indent=2, separators=(',',':')))
@@ -703,6 +717,9 @@ editor.
         core.load_files()
         core.write("index.html")
         left = "posted to "+config.LIVE+config.USER+"/"+str(SETTINGS.get("publish dir"))+"/index.html\n\n>"
+
+    if SETTINGS['gopher']:
+        gopher.publish_gopher('feels', core.get_files())
     redraw(left + " thanks for sharing your feels!")
 
     return

--- a/ttbp/ttbp.py
+++ b/ttbp/ttbp.py
@@ -43,7 +43,7 @@ import tempfile
 import subprocess
 import time
 import json
-from email.mime.text import MIMEText;
+from email.mime.text import MIMEText
 import datetime
 
 import inflect

--- a/ttbp/ttbp.py
+++ b/ttbp/ttbp.py
@@ -77,7 +77,7 @@ RAINBOW = False
 
 ## ref
 
-EDITORS = ["vim", "vi", "emacs", "pico", "nano", "ed"]
+EDITORS = ["vim", "vi", "emacs", "pico", "nano", "ed", "micro"]
 SUBJECTS = ["help request", "bug report", "feature suggestion", "general comment"]
 
 ## ttbp specific utilities

--- a/ttbp/ttbp.py
+++ b/ttbp/ttbp.py
@@ -30,11 +30,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 the complete codebase is available at:
 https://github.com/modgethanc/ttbp
-
-
-TODO ability to opt into gopher publishing
-TODO check for existing public_gopher / gophermap
-TODO write out files
 '''
 from __future__ import absolute_import
 

--- a/ttbp/util.py
+++ b/ttbp/util.py
@@ -212,8 +212,4 @@ def input_yn(query):
     while ans not in ["y", "n"]:
         ans = raw_input("'y' or 'n' please: ")
 
-    if ans == "y":
-        return True
-    else:
-        return False
-
+    return ans == "y"


### PR DESCRIPTION
This PR:

- Adds support for Gopher, which means:
 - opt in / opt out of gopher publishing
 - copies user files to ~/public_gopher/feels
 - generates a gopher map
- Does minor cleanup
 - removes some unused imports
 - removes semicolon
 - streamlines some code

Open questions:

- Is the opt in / opt out sufficient for now in terms of configurability?
- Does copying the files into `public_gopher` make sense? Should they be linked?
- Should the gophermap say anything else?